### PR TITLE
Use fgetc result instead of feof for loop-breaking

### DIFF
--- a/src/ContentStream.php
+++ b/src/ContentStream.php
@@ -6,7 +6,6 @@ use Exception;
 use function abs;
 use function assert;
 use function fclose;
-use function feof;
 use function fgetc;
 use function file_exists;
 use function fopen;
@@ -57,9 +56,11 @@ class ContentStream
             // cache all data if stream is not seekable
             $meta = stream_get_meta_data($source);
             if (!$meta['seekable']) {
-                while (!feof($source)) {
+                while (true) {
                     $character = fgetc($source);
-                    assert($character !== false);
+                    if ($character === false) {
+                        break;
+                    }
 
                     $this->read[] = ord($character);
                 }


### PR DESCRIPTION
The previous code randomly failed in ~1% of cases when loading file info of FB avatars in production container `channel-integration-facebook-public:21.3.3`. The `fgetc` returned `false` as if reading an EOF.

Usually, this behavior would be expected (`feof` reads current byte, `fgetc` reads next one) and the code would fail every time when loading a local file. Of course, it doesn't get executed because of the condition `if (is_string($source) && file_exists($source))` above.

With a dev Docker image, I've never experienced the issue, only when running production. I'm not sure what causes the randomness of the results, what causes the difference between production and dev image, or why does `feof` work differently with streams than with files.

My best guess is that after reading the last byte, the socket closes, making the `feof` return true, even when the current byte is not EOF. In practice, it manages to close before the next loop is executed only in ~99% cases, hence the random results. Dev and prod images have either different config for connections, or it's the extra optimization (eg. not executing the `assert`) that makes it execute the loop quickly enough before the socket closes.

The resulting code is basically the same according to docs and in practice (in the context of detecting file info in `channel-integration-facebook-public:21.3.3`), I've never seen it cause any problems.