### PR TITLE
FileInfo: always has file type and mime type

### DIFF
--- a/src/DetectorTest.php
+++ b/src/DetectorTest.php
@@ -236,7 +236,6 @@ class DetectorTest extends TestCase
         string $expectedMimeType
     ): void {
         $fileType = $fileInfo->getFileType();
-        assert($fileType !== null);
 
         Assert::assertSame($expectedFileType, $fileType->getValue());
         Assert::assertSame($expectedExtension, $fileInfo->getExtension()->getValue());

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -134,6 +134,7 @@ class Extension extends Enum
         self::DAR => 'application/x-dar',
 
         self::ISO => 'application/x-iso9660-image',
+        self::VHD => 'application/x-vhd',
 
         self::ACCDB => 'application/x-msaccess',
         self::MDB => 'application/x-msaccess',

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -184,6 +184,7 @@ class Extension extends Enum
         self::TSV => 'text/tab-separated-values',
 
         self::_3GP => 'video/3gpp',
+        self::ASF => 'application/vnd.ms-asf',
         self::AVI => 'video/x-msvideo',
         self::FLV => 'video/x-flv',
         self::M4V => 'video/x-m4v',

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -3,7 +3,9 @@
 namespace BrandEmbassy\FileTypeDetector;
 
 use InvalidArgumentException;
+use LogicException;
 use MabeEnum\Enum;
+use function sprintf;
 
 /**
  * @method string getValue()
@@ -218,8 +220,12 @@ class Extension extends Enum
     }
 
 
-    public function findMimeType(): ?string
+    public function findMimeType(): string
     {
-        return self::$mimeTypes[$this->getValue()] ?? null;
+        if (!isset(self::$mimeTypes[$this->getValue()])) {
+            throw new LogicException(sprintf('Mime type for extension "%s" does not exist.', $this->getValue()));
+        }
+
+        return self::$mimeTypes[$this->getValue()];
     }
 }

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -134,6 +134,7 @@ class Extension extends Enum
         self::DAR => 'application/x-dar',
 
         self::ISO => 'application/x-iso9660-image',
+        self::NRG => 'application/x-nrg',
         self::VHD => 'application/x-vhd',
 
         self::ACCDB => 'application/x-msaccess',

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -6,6 +6,8 @@ use InvalidArgumentException;
 use LogicException;
 use MabeEnum\Enum;
 use function sprintf;
+use function trigger_error;
+use const E_USER_DEPRECATED;
 
 /**
  * @method string getValue()
@@ -220,12 +222,25 @@ class Extension extends Enum
     }
 
 
-    public function findMimeType(): string
+    public function getMimeType(): string
     {
         if (!isset(self::$mimeTypes[$this->getValue()])) {
             throw new LogicException(sprintf('Mime type for extension "%s" does not exist.', $this->getValue()));
         }
 
         return self::$mimeTypes[$this->getValue()];
+    }
+
+
+    /**
+     * @deprecated use getMimeType instead
+     *
+     * @see self::getMimeType()
+     */
+    public function findMimeType(): ?string
+    {
+        @trigger_error(sprintf('Method %s is deprecated.', __METHOD__), E_USER_DEPRECATED);
+
+        return $this->getMimeType();
     }
 }

--- a/src/FileInfo.php
+++ b/src/FileInfo.php
@@ -13,12 +13,12 @@ class FileInfo
     private $extension;
 
     /**
-     * @var FileType|null
+     * @var FileType
      */
     private $fileType;
 
     /**
-     * @var string|null
+     * @var string
      */
     private $mimeType;
 
@@ -43,13 +43,13 @@ class FileInfo
     }
 
 
-    public function getFileType(): ?FileType
+    public function getFileType(): FileType
     {
         return $this->fileType;
     }
 
 
-    public function getMimeType(): ?string
+    public function getMimeType(): string
     {
         return $this->mimeType;
     }

--- a/src/FileInfo.php
+++ b/src/FileInfo.php
@@ -31,8 +31,8 @@ class FileInfo
     public function __construct(Extension $extension, bool $isCreatedFromFileName)
     {
         $this->extension = $extension;
-        $this->fileType = FileType::findByExtension($extension);
-        $this->mimeType = $extension->findMimeType();
+        $this->fileType = FileType::getByExtension($extension);
+        $this->mimeType = $extension->getMimeType();
         $this->isCreatedFromFileName = $isCreatedFromFileName;
     }
 

--- a/src/FileInfoTest.php
+++ b/src/FileInfoTest.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassy\FileTypeDetector;
+
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+use ZipArchive;
+use function array_map;
+use function assert;
+use function fclose;
+use function file_get_contents;
+use function fopen;
+use function fwrite;
+use function implode;
+use function is_resource;
+use function rewind;
+use function sprintf;
+use function stream_get_meta_data;
+use function sys_get_temp_dir;
+use function tempnam;
+
+class FileInfoTest extends TestCase
+{
+    /**
+     * @dataProvider extensionDataProvider()
+     */
+    public function testFileInfoHasFileType(Extension $extension): void {
+        $fileInfo = new FileInfo($extension, true);
+
+        Assert::assertNotNull(
+            $fileInfo->getFileType(),
+            sprintf('Extension "%s" has no file type.', $extension->getValue())
+        );
+    }
+
+    /**
+     * @dataProvider extensionDataProvider()
+     */
+    public function testFileInfoHasMimeType(Extension $extension): void {
+        $fileInfo = new FileInfo($extension, true);
+
+        Assert::assertNotNull(
+            $fileInfo->getMimeType(),
+            sprintf('Extension "%s" has no mime type.', $extension->getValue())
+        );
+    }
+
+
+    /**
+     * @return Extension[][]
+     */
+    public function extensionDataProvider(): iterable
+    {
+        foreach (Extension::getValues() as $value) {
+            yield [Extension::get($value)];
+        }
+    }
+}

--- a/src/FileInfoTest.php
+++ b/src/FileInfoTest.php
@@ -4,27 +4,15 @@ namespace BrandEmbassy\FileTypeDetector;
 
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
-use ZipArchive;
-use function array_map;
-use function assert;
-use function fclose;
-use function file_get_contents;
-use function fopen;
-use function fwrite;
-use function implode;
-use function is_resource;
-use function rewind;
 use function sprintf;
-use function stream_get_meta_data;
-use function sys_get_temp_dir;
-use function tempnam;
 
 class FileInfoTest extends TestCase
 {
     /**
      * @dataProvider extensionDataProvider()
      */
-    public function testFileInfoHasFileType(Extension $extension): void {
+    public function testFileInfoHasFileType(Extension $extension): void
+    {
         $fileInfo = new FileInfo($extension, true);
 
         Assert::assertNotNull(
@@ -33,10 +21,12 @@ class FileInfoTest extends TestCase
         );
     }
 
+
     /**
      * @dataProvider extensionDataProvider()
      */
-    public function testFileInfoHasMimeType(Extension $extension): void {
+    public function testFileInfoHasMimeType(Extension $extension): void
+    {
         $fileInfo = new FileInfo($extension, true);
 
         Assert::assertNotNull(

--- a/src/FileInfoTest.php
+++ b/src/FileInfoTest.php
@@ -9,36 +9,27 @@ class FileInfoTest extends TestCase
     /**
      * @dataProvider extensionDataProvider()
      */
-    public function testFileInfoHasFileType(Extension $extension): void
+    public function testFileInfoAlwaysHasAllAttributes(Extension $extension, bool $isCreatedFromFileName): void
     {
-        $fileInfo = new FileInfo($extension, true);
+        $fileInfo = new FileInfo($extension, $isCreatedFromFileName);
 
+        $fileInfo->getExtension();
         $fileInfo->getFileType();
-
-        $this->expectNotToPerformAssertions();
-    }
-
-
-    /**
-     * @dataProvider extensionDataProvider()
-     */
-    public function testFileInfoHasMimeType(Extension $extension): void
-    {
-        $fileInfo = new FileInfo($extension, true);
-
         $fileInfo->getMimeType();
+        $fileInfo->isCreatedFromFileName();
 
         $this->expectNotToPerformAssertions();
     }
 
 
     /**
-     * @return Extension[][]
+     * @return iterable<array<Extension|bool>>
      */
     public function extensionDataProvider(): iterable
     {
         foreach (Extension::getValues() as $value) {
-            yield [Extension::get($value)];
+            yield [Extension::get($value), true];
+            yield [Extension::get($value), false];
         }
     }
 }

--- a/src/FileInfoTest.php
+++ b/src/FileInfoTest.php
@@ -2,9 +2,7 @@
 
 namespace BrandEmbassy\FileTypeDetector;
 
-use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
-use function sprintf;
 
 class FileInfoTest extends TestCase
 {
@@ -15,10 +13,9 @@ class FileInfoTest extends TestCase
     {
         $fileInfo = new FileInfo($extension, true);
 
-        Assert::assertNotNull(
-            $fileInfo->getFileType(),
-            sprintf('Extension "%s" has no file type.', $extension->getValue())
-        );
+        $fileInfo->getFileType();
+
+        $this->expectNotToPerformAssertions();
     }
 
 
@@ -29,10 +26,9 @@ class FileInfoTest extends TestCase
     {
         $fileInfo = new FileInfo($extension, true);
 
-        Assert::assertNotNull(
-            $fileInfo->getMimeType(),
-            sprintf('Extension "%s" has no mime type.', $extension->getValue())
-        );
+        $fileInfo->getMimeType();
+
+        $this->expectNotToPerformAssertions();
     }
 
 

--- a/src/FileType.php
+++ b/src/FileType.php
@@ -2,8 +2,10 @@
 
 namespace BrandEmbassy\FileTypeDetector;
 
+use LogicException;
 use MabeEnum\Enum;
 use function in_array;
+use function sprintf;
 
 /**
  * @method string getValue()
@@ -153,7 +155,7 @@ class FileType extends Enum
     ];
 
 
-    public static function findByExtension(Extension $extension): ?self
+    public static function findByExtension(Extension $extension): self
     {
         foreach (self::$extensionsMap as $fileType => $extensions) {
             if (in_array($extension->getValue(), $extensions, true)) {
@@ -161,6 +163,6 @@ class FileType extends Enum
             }
         }
 
-        return null;
+        throw new LogicException(sprintf('File type for extension "%s" does not exist.', $extension->getValue()));
     }
 }

--- a/src/FileType.php
+++ b/src/FileType.php
@@ -6,6 +6,8 @@ use LogicException;
 use MabeEnum\Enum;
 use function in_array;
 use function sprintf;
+use function trigger_error;
+use const E_USER_DEPRECATED;
 
 /**
  * @method string getValue()
@@ -155,7 +157,7 @@ class FileType extends Enum
     ];
 
 
-    public static function findByExtension(Extension $extension): self
+    public static function getByExtension(Extension $extension): self
     {
         foreach (self::$extensionsMap as $fileType => $extensions) {
             if (in_array($extension->getValue(), $extensions, true)) {
@@ -164,5 +166,18 @@ class FileType extends Enum
         }
 
         throw new LogicException(sprintf('File type for extension "%s" does not exist.', $extension->getValue()));
+    }
+
+
+    /**
+     * @deprecated use getByExtension instead
+     *
+     * @see self::getByExtension()
+     */
+    public function findByExtension(Extension $extension): ?self
+    {
+        @trigger_error(sprintf('Method %s is deprecated.', __METHOD__), E_USER_DEPRECATED);
+
+        return self::getByExtension($extension);
     }
 }


### PR DESCRIPTION
Nullability of FileType and MimeType introduced in #5 makes FileInfo object hard to work with. This PR aims to investigate whether it's necessary and help with the issue, ideally by making all properties non-nullable.